### PR TITLE
Update low-precision to pull in low queries.

### DIFF
--- a/.github/codeql/low-precision.yml
+++ b/.github/codeql/low-precision.yml
@@ -1,8 +1,19 @@
 name: "Custom CodeQL Config for lower precision"
 disable-default-queries: true
-queries:
-  - uses: security-extended
-  - uses: security-and-quality
+# queries:
+# The following suites alredy have the low precision queries filtered out
+#   - uses: security-extended
+#   - uses: security-and-quality
+packs:         
+    # All queries from the CodeQL Built in packs (including low/no precision queries)
+    - codeql/cpp-queries:.    
+    - codeql/csharp-queries:.    
+    - codeql/go-queries:.    
+    - codeql/java-queries:.
+    - codeql/javascript-queries:.
+    - codeql/python-queries:.
+    - codeql/ruby-queries:.
+    - codeql/swift-queries:.
 query-filters:
 - include:
     kind:


### PR DESCRIPTION
Enhance `.github/codeql/low-precision.yml` file
- The change modifies the CodeQL configuration for lower precision to use built-in query packs instead of the previously used suites. The suites that were commented out already had the[ low precision queries filtered out](https://github.com/github/codeql/blob/fd7bd6b07d6afc0d88daeb0ee6db83e75dfb972b/misc/suite-helpers/code-scanning-selectors.yml#L8-L10), so this change will include all queries from the CodeQL built-in packs, including low and no precision queries. This is done for all CodeQL languages including C++, C#, Go, Java, JavaScript, Python, Ruby, and Swift.


Ref: https://colinsalmcorner.com/fine-tuning-codeql-scans/